### PR TITLE
lexical-binding setting must be in first line

### DIFF
--- a/flyspell-correct.el
+++ b/flyspell-correct.el
@@ -1,4 +1,4 @@
-;;; flyspell-correct.el --- correcting words with flyspell via custom interface
+;;; flyspell-correct.el --- correcting words with flyspell via custom interface -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2016 Boris Buliga
 ;;
@@ -14,7 +14,6 @@
 ;;
 ;;; Code:
 ;;
-;;; -*- lexical-binding: t -*-
 
 ;; Requires
 


### PR DESCRIPTION
See
- https://www.gnu.org/software/emacs/manual/html_node/elisp/Using-Lexical-Binding.html


> Variable: lexical-binding
>
 >  If this buffer-local variable is non-nil, Emacs Lisp files and buffers are evaluated using lexical binding instead of dynamic binding. (However, special variables are still dynamically bound; see below.) If nil, dynamic binding is used for all local variables. This variable is typically set for a whole Emacs Lisp file, as a file local variable (see File Local Variables). Note that unlike other such variables, this one must be set in the first line of a file. 

Please see last sentence.