### PR TITLE
Fix void variable word (#9)

### DIFF
--- a/flyspell-correct.el
+++ b/flyspell-correct.el
@@ -122,9 +122,8 @@ of (command, word) to be used by `flyspell-do-correct'."
                          :candidate-number-limit 9999
                          :fuzzy-match t)
                        (helm-build-sync-source "Options"
-                         :candidates '(lambda ()
-                                        (let ((tmp word))
-                                           (flyspell-correct--helm-option-candidates tmp)))
+                         :candidates (lambda ()
+                                       (flyspell-correct--helm-option-candidates word))
                          :action 'identity
                          :candidate-number-limit 9999
                          :match 'flyspell-correct--helm-always-match

--- a/flyspell-correct.el
+++ b/flyspell-correct.el
@@ -85,9 +85,6 @@ of (command, word) to be used by `flyspell-do-correct'."
 (declare-function helm-build-sync-source "ext:helm-source.el"
                   (name &rest args))
 
-(defvar flyspell-correct--helm-options-word nil
-  "Internal variable to hold current word.")
-
 (defun flyspell-correct--helm-always-match (_)
   "Return non-nil for any CANDIDATE."
   t)
@@ -115,7 +112,6 @@ of (command, word) to be used by `flyspell-do-correct'."
   "Run helm for the given CANDIDATES given by flyspell for the WORD.
 Return a selected word to use as a replacement or a tuple
 of (command, word) to be used by `flyspell-do-correct'."
-  (setq flyspell-correct--helm-options-word word)
   (helm :sources (list (helm-build-sync-source
                            (format "Suggestions for \"%s\" in dictionary \"%s\""
                                    word (or ispell-local-dictionary
@@ -127,8 +123,8 @@ of (command, word) to be used by `flyspell-do-correct'."
                          :fuzzy-match t)
                        (helm-build-sync-source "Options"
                          :candidates '(lambda ()
-                                        (flyspell-correct--helm-option-candidates
-                                         flyspell-correct--helm-options-word))
+                                        (let ((tmp word))
+                                           (flyspell-correct--helm-option-candidates tmp)))
                          :action 'identity
                          :candidate-number-limit 9999
                          :match 'flyspell-correct--helm-always-match


### PR DESCRIPTION
I verified that I got the error without your workaround and that I don't get it with my (proper) fix.

My explanation (the commit message of fe6abbe):

> When a lambda (closure) is quoted, the byte-compiler and/or
interpreter (probably, I haven't verified it) doesn't know that the
`word` variable is a lexical reference. When later invoking the lambda,
the `word` variable will be void as it was not detected as part of the
closure.