### PR TITLE
add tests for flyspell-correct-next function

### DIFF
--- a/flyspell-correct.el
+++ b/flyspell-correct.el
@@ -196,7 +196,7 @@ Uses `flyspell-correct-at-point' function for correction."
         (narrow-to-region top bot)
         (overlay-recenter (point))
 
-        (let ((overlay-list (overlays-in position (point-max)))
+        (let ((overlay-list (overlays-in (- position 1) (point-max)))
               (overlay 'dummy-value))
 
           (while overlay

--- a/test/flyspell-correct-test.el
+++ b/test/flyspell-correct-test.el
@@ -39,3 +39,45 @@ cursor is after the word."
   (with-mistake-in-the-middle|cursor-after
    (ensure-correction "versiuns" "versions")
    (flyspell-correct-previous (point))))
+
+(ert-deftest flyspell-correct-next-no-mistakes-test ()
+  "Test that `flyspell-correct-next' doesn't correct any word
+in a buffer with no mistakes."
+  (with-no-mistakes
+   (ensure-no-corrections)
+   (flyspell-correct-next (point))))
+
+(ert-deftest flyspell-correct-next-cursor-beginning-test ()
+  "Test that `flyspell-correct-next' corrects a word when
+cursor is at the beginning of the word."
+  (with-mistake-in-the-middle|cursor-beginning
+   (ensure-correction "versiuns" "versions")
+   (flyspell-correct-next (point))))
+
+(ert-deftest flyspell-correct-next-cursor-before-test ()
+  "Test that `flyspell-correct-next' doesn't correct any word
+when cursor is before the word."
+  (with-mistake-in-the-middle|cursor-before
+   (ensure-correction "versiuns" "versions")
+   (flyspell-correct-next (point))))
+
+(ert-deftest flyspell-correct-next-cursor-inside-test ()
+  "Test that `flyspell-correct-next' corrects a word when
+cursor is inside of the word."
+  (with-mistake-in-the-middle|cursor-inside
+   (ensure-correction "versiuns" "versions")
+   (flyspell-correct-next (point))))
+
+(ert-deftest flyspell-correct-next-cursor-end-test ()
+  "Test that `flyspell-correct-next' corrects a word when
+cursor is at the end of the word."
+  (with-mistake-in-the-middle|cursor-end
+   (ensure-correction "versiuns" "versions")
+   (flyspell-correct-next (point))))
+
+(ert-deftest flyspell-correct-next-cursor-after-test ()
+  "Test that `flyspell-correct-next' corrects a word when
+cursor is after the word."
+  (with-mistake-in-the-middle|cursor-after
+   (ensure-no-corrections)
+   (flyspell-correct-next (point))))


### PR DESCRIPTION
and actually fix the problem with correction of word at point