### PR TITLE
fix end-comment in flyspell-correct-ivy.el

### DIFF
--- a/flyspell-correct-ivy.el
+++ b/flyspell-correct-ivy.el
@@ -64,4 +64,4 @@ of (command, word) to be used by `flyspell-do-correct'."
 
 (provide 'flyspell-correct-ivy)
 
-;;; flyspell-correct-helm.el ends here
+;;; flyspell-correct-ivy.el ends here


### PR DESCRIPTION
Nice package!
Fix end-comments a bit.