### PR TITLE
allow to save and correct in one pass

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,7 @@
   =flyspell-correct-move=, so there is no difference in resulting point location
   when any of these functions is called with point at misspelled word.
 - Rewrite all tests using [[https://github.com/jorgenschaefer/emacs-buttercup][buttercup]] library.
+- Allow to correct and save the word in one pass (see #66).
 
 * v0.6.1
 

--- a/flyspell-correct.el
+++ b/flyspell-correct.el
@@ -148,15 +148,20 @@ Adapted from `flyspell-correct-word-before-point'."
                   ;; stop rapid mode. So when interface returns nil we treat it
                   ;; as a stop. Fixes #60.
                   (unless res (setq res (cons 'stop word)))
-                  (cond ((stringp res)
-                         (flyspell-do-correct res poss word cursor-location start end opoint))
-                        (t
-                         (let ((cmd (car res))
-                               (wrd (cdr res)))
-                           (unless (or (eq cmd 'skip)
-                                       (eq cmd 'stop))
-                             (flyspell-do-correct
-                              cmd poss wrd cursor-location start end opoint)))))
+                  (cond
+                   ((stringp res)
+                    (flyspell-do-correct
+                     res poss word cursor-location start end opoint))
+                   (t
+                    (let ((cmd (car res))
+                          (wrd (cdr res)))
+                      (unless (or (eq cmd 'skip)
+                                  (eq cmd 'stop))
+                        (flyspell-do-correct
+                         cmd poss wrd cursor-location start end opoint)
+                        (unless (string-equal wrd word)
+                          (flyspell-do-correct
+                           wrd poss word cursor-location start end opoint))))))
                   (ispell-pdict-save t))))))
       (flyspell-correct--highlight-remove))
     res))

--- a/test/test-flyspell-correct.el
+++ b/test/test-flyspell-correct.el
@@ -290,7 +290,34 @@ Simply passed WORD to `correct-word' mock."
     (it "call correct when the cursor is at the end of misspelled word"
       (with-mistakes|cursor-end
        (expect (flyspell-correct-at-point) :to-equal "versions")
-       (expect-correction "versiuns" "versions")))))
+       (expect-correction "versiuns" "versions"))))
+
+  (describe "action - save"
+    (before-each
+      (spy-on 'flyspell-do-correct)
+      (spy-on 'correct-interface :and-call-through))
+
+    (it "save the misspelled word"
+      (with-mistakes|cursor-inside
+       (spy-on 'correct-word :and-return-value (cons 'save "versions"))
+
+       (expect (flyspell-correct-at-point) :to-equal (cons 'save "versions"))
+       (expect 'flyspell-do-correct :to-have-been-called-with-nth 0 'save)
+       (expect 'flyspell-do-correct :to-have-been-called-with-nth 2 "versions")))
+
+    (it "correct misspelled word and save correction"
+      (with-mistakes|cursor-end
+       (spy-on 'correct-word :and-return-value (cons 'save "versens"))
+
+       (expect (flyspell-correct-at-point) :to-equal (cons 'save "versens"))
+       (expect (flyspell-correct-at-point) :to-equal (cons 'save "versens"))
+
+       ;; save
+       (expect 'flyspell-do-correct :to-have-been-called-with-nth 0 'save)
+       (expect 'flyspell-do-correct :to-have-been-called-with-nth 2 "versens")
+
+       ;; correct
+       (expect 'flyspell-do-correct :to-have-been-called-with-nth 0 "versens")))))
 
 (describe "flyspell-correct-next"
 


### PR DESCRIPTION
Fixes #66

Currently applicable only to `flyspell-correct-helm` interface.