### PR TITLE
expose flyspell-correct-ivy-map and result

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,6 +19,8 @@
 - New action - =stop= allowing to leave the point at the misspelled word.
 - =skip= action now allows to correct 'next' word even if rapid mode is not
   enabled (#58).
+- Allow to hook into =flyspell-correct-ivy= interface via
+  =flyspell-correct-ivy-map= (fixes #58, see example in #72).
 
 * v0.6.1
 

--- a/flyspell-correct-ivy.el
+++ b/flyspell-correct-ivy.el
@@ -5,7 +5,7 @@
 ;; Author: Boris Buliga <boris@d12frosted.io>
 ;; URL: https://github.com/d12frosted/flyspell-correct
 ;; Version: 0.6.1
-;; Package-Requires: ((flyspell-correct "0.6.1") (ivy "0.8.0") (emacs "24"))
+;; Package-Requires: ((flyspell-correct "0.6.1") (ivy "0.8.0") (emacs "24.3"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -39,21 +39,41 @@
 
 ;; Interface implementation
 
+(defvar flyspell-correct-ivy-map (make-sparse-keymap)
+  "Keymap used in the `flyspell-correct-ivy' minibuffer.")
+
+(defvar-local flyspell-correct-ivy--result nil
+  "Result of `flyspell-correct-ivy'.
+
+See `flyspell-correct-interface' for more information.")
+
 ;;;###autoload
 (defun flyspell-correct-ivy (candidates word)
   "Run `ivy-read' for the given CANDIDATES.
 
 List of CANDIDATES is given by flyspell for the WORD.
 
-Return a selected word to use as a replacement or a tuple
-of (command, word) to be used by `flyspell-do-correct'."
-  (let* (result
-         (action-default (lambda (x) (setq result x)))
-         (action-save-word (lambda (_) (setq result (cons 'save word))))
-         (action-accept-session (lambda (_) (setq result (cons 'session word))))
-         (action-accept-buffer (lambda (_) (setq result (cons 'buffer word))))
-         (action-skip-word (lambda (_) (setq result (cons 'skip word))))
-         (action-stop (lambda (_) (setq result (cons 'stop word))))
+Return result according to `flyspell-correct-interface'
+specification."
+  (setq flyspell-correct-ivy--result nil)
+  (let* ((action-default
+          (lambda (x)
+            (setq flyspell-correct-ivy--result x)))
+         (action-save-word
+          (lambda (_)
+            (setq flyspell-correct-ivy--result (cons 'save word))))
+         (action-accept-session
+          (lambda (_)
+            (setq flyspell-correct-ivy--result (cons 'session word))))
+         (action-accept-buffer
+          (lambda (_)
+            (setq flyspell-correct-ivy--result (cons 'buffer word))))
+         (action-skip-word
+          (lambda (_)
+            (setq flyspell-correct-ivy--result (cons 'skip word))))
+         (action-stop
+          (lambda (_)
+            (setq flyspell-correct-ivy--result (cons 'stop word))))
          (action `(1
                    ("o" ,action-default "correct")
                    ("s" ,action-save-word "Save")
@@ -67,8 +87,9 @@ of (command, word) to be used by `flyspell-do-correct'."
                                "Default"))
               candidates
               :action action
+              :keymap flyspell-correct-ivy-map
               :caller 'flyspell-correct-ivy)
-    result))
+    flyspell-correct-ivy--result))
 
 (setq flyspell-correct-interface #'flyspell-correct-ivy)
 


### PR DESCRIPTION
Fixes #58

This change allows users to hook into the interface and modify result to their
liking. As example, one can define a key binding for skipping a word:

```emacs-lisp
(defun flyspell-correct-ivy-skip ()
  (interactive)
  (ivy-exit-with-action
   (lambda (_) (setq flyspell-correct-ivy--result (cons 'skip "")))))

(define-key flyspell-correct-ivy-map (kbd "C-;") #'flyspell-correct-ivy-skip)
```

But please be careful when modifying `flyspell-correct-ivy--result`. While it's
structure rarely change, it does change time to time. See
`flyspell-correct-interface` for more information.