### PR TITLE
Polish mark setting behavior of flyspell-correct-move

### DIFF
--- a/flyspell-correct.el
+++ b/flyspell-correct.el
@@ -359,7 +359,9 @@ until all errors in buffer have been addressed."
                              ;; don't push mark if there is no change
                              (not (memq (car-safe res) '(stop break skip)))
                              (/= (mark t) (point)))
-                        (push-mark (point) t)))))))))
+                        ;; `flyspell-correct-at-point' may move point, use
+                        ;; original `incorrect-word-pos' instead
+                        (push-mark incorrect-word-pos t)))))))))
 
       (when hard-move-point
         (when mark-opos


### PR DESCRIPTION
Following discussion at #80.

- Make `flyspell-correct-move` push the mark more conservatively, namely only
  when there is actual change in the overlays, that is, refraining to do so on
  `skip`, `stop` or `break` actions.

- Push the mark at the top of the mark-ring when leaving with action `stop`,
  to be able to easily return to original point position in that case.

- The initial mark pushed at `flyspell-correct-wrapper` was brought to
  `flyspell-correct-move` to ensure consistency of behavior between the
  `-wrapper` and `-next`/`-previous` commands.  A clean-up check for this mark
  was included.