### PR TITLE
flyspell-correct-completing-read: Improve shortcut key

### DIFF
--- a/README.org
+++ b/README.org
@@ -117,8 +117,13 @@ If you do not want any binding, just replace =:bind (:map
 flyspell-mode-map ("C-;" . flyspell-correct-wrapper))= with =:defer t=
 to use lazy loading.
 
-In order to select the (s)ave, (a)ccept, sto(p) or s(k)ip actions, you can
-enter the shortcut key @s, @a, @p or @k.
+In order to select the (s)ave, (a)ccept, sto(p) or s(k)ip actions, you can enter
+the shortcut key =@s=, =@a=, =@p= or =@k=. The actions will be automatically submitted.
+Furthermore suggestions can be quickly submitted by entering the numeric index
+in front of the suggestion. Besides the quick keys the usual ~completing-read~
+interface is available, which may be enhanced and allow scrolling through
+candidates if you have a completion UI like Icomplete-vertical, Selectrum or
+Vertico installed.
 
 ** =flyspell-correct-ivy= interface
 :PROPERTIES:

--- a/README.org
+++ b/README.org
@@ -122,8 +122,8 @@ the shortcut key =@s=, =@a=, =@p= or =@k=. The actions will be automatically sub
 Furthermore suggestions can be quickly submitted by entering the numeric index
 in front of the suggestion. Besides the quick keys the usual ~completing-read~
 interface is available, which may be enhanced and allow scrolling through
-candidates if you have a completion UI like Icomplete-vertical, Selectrum or
-Vertico installed.
+candidates if you have a completion UI like [[https://github.com/oantolin/icomplete-vertical][Icomplete-vertical]], [[https://github.com/raxod502/selectrum][Selectrum]] or
+[[https://github.com/minad/vertico][Vertico]] installed.
 
 ** =flyspell-correct-ivy= interface
 :PROPERTIES:

--- a/flyspell-correct-ido.el
+++ b/flyspell-correct-ido.el
@@ -47,7 +47,8 @@ Return a selected word to use as a replacement or a tuple
 of (command, word) to be used by `flyspell-do-correct'."
   (let ((completing-read-function
          (lambda (prompt collection &rest _)
-           (ido-completing-read prompt (all-completions "" collection)))))
+           (ido-completing-read prompt (all-completions "" collection)
+                                nil nil nil nil word))))
     (flyspell-correct-completing-read candidates word)))
 
 (setq flyspell-correct-interface #'flyspell-correct-ido)

--- a/flyspell-correct.el
+++ b/flyspell-correct.el
@@ -123,7 +123,13 @@ highlighting."
   "Actions used by `flyspell-correct-completing-read'.")
 
 (defun flyspell-correct--cr-index (n)
-  "Generate a short unique index string for N."
+  "Generate a short unique index string for N.
+
+The index string is used to prefix suggestion candidates. The digits 12345
+encode (mod n 5) and occur as suffix of the index string. If one of the keys
+12345 is pressed, the selected candidate is automatically submitted. The
+remaining value (/ n 5) is encoded using the digits 67890, which occur in the
+prefix of the index string."
   (let ((str (char-to-string (+ ?1 (mod n 5)))))
     (when (>= n 5)
       (setq n (/ (- n 5) 5))


### PR DESCRIPTION
The RET is pressed automatically for you.

(Follow up on #92 - I used it for a while and figured that pressing the RET after the actions is a bit tedious.)