### PR TITLE
Add `defgroup' for customization options

### DIFF
--- a/flyspell-correct.el
+++ b/flyspell-correct.el
@@ -60,6 +60,11 @@
 
 ;; Variables
 
+(defgroup flyspell-correct nil
+  "Correcting words with flyspell via a custom interface."
+  :prefix "flyspell-correct-"
+  :group 'flyspell)
+
 (defcustom flyspell-correct-interface #'flyspell-correct-completing-read
   "Interface for `flyspell-correct-at-point'.
 


### PR DESCRIPTION
`defgroup` enables the Custom buffer to link to its parent group, which I made `flyspell` here. Though now that I'm looking at the other variables in this file, I'm not sure what the thinking is behind some options/modes being under `flyspell` and some being under `flyspell-correct`.