### PR TITLE
Add metadata category of `flyspell' to completions

### DIFF
--- a/flyspell-correct.el
+++ b/flyspell-correct.el
@@ -171,6 +171,7 @@ of (command, word) to be used by `flyspell-do-correct'."
                                         "default")))
          (actions-title (format "Actions (Shortcut key %s)" flyspell-correct--cr-key))
          (metadata `(metadata
+                     (category . flyspell)
                      (display-sort-function . ,#'identity)
                      (cycle-sort-function . ,#'identity)
                      (group-function


### PR DESCRIPTION
This allows e.g., `vertico-multiform` to properly detect `flyspell-correct-wrapper` calls.

I'm not sure if `flyspell` is a good category here; feel free to change it. Other options might be `spell` or `ispell`.